### PR TITLE
Change the tool file to optionally exclude CUDA-specific parts of the installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,11 @@ poetry install
 poetry shell
 ```
 
+Note: if you are working on a machine without a CUDA-enabled GPU, install the CPU-only version:
+```bash
+poetry install --without cuda
+```
+
 ## Usage 🧪
 
 Our code uses [Hydra](https://hydra.cc/) to configure experiments. Each experiment is defined as a `yaml` file in `ss2r/configs/experiments`. For example, to train a Unitree Go1 policy with a constraint on joint limit:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,21 +9,24 @@ readme = "README.md"
 python = "^3.11.6,<3.12"
 mujoco = "3.3.0"
 mujoco-mjx = "3.2.7"
-jax = {version = "0.4.34", extras = ["cuda12"]}
+jax = "0.4.34"  # CPU-only version
 hydra-core = "^1.3.2"
 hydra-submitit-launcher = "^1.2.0"
 tabulate = "^0.9.0"
-nvidia-cublas-cu12 = "12.9.0.13"
 moviepy = "1.0.3"
 imageio = "^2.37.0"
 # TODO (yarden): update these once they are merged to main
 brax = {git = "https://github.com/Andrew-Luo1/brax.git", rev = "bc_checkpointing"}
 playground = {git = "https://github.com/Andrew-Luo1/mujoco_playground_new.git"}
-nvidia-cuda-nvrtc-cu12 = "^12.9.86"
 
 [[tool.poetry.source]]
 name = "PyPI"
 priority = "primary"
+
+[tool.poetry.group.cuda.dependencies]
+nvidia-cublas-cu12 = "12.9.0.13"
+nvidia-cuda-nvrtc-cu12 = "^12.9.86"
+jax = {version = "0.4.34", extras = ["cuda12"]}
 
 [tool.poetry.group.dev]
 optional = true


### PR DESCRIPTION
I added a group that can optionally be deactivated in Poetry installation, in order to be able to install it on devices without CUDA.