### PR TITLE
Variable goal size for go-to-goal environment

### DIFF
--- a/ss2r/configs/environment/go_to_goal.yaml
+++ b/ss2r/configs/environment/go_to_goal.yaml
@@ -7,6 +7,7 @@ task_params:
   visualize_lidar: False 
   num_hazards: 10
   num_vases: 10
+  goal_size: 0.3
 
 train_params:
   damping:


### PR DESCRIPTION
The goal size for the go-to-goal environment can be set through the environment task parameters, eg.: `+environment.task_params.goal_size=0.5` and is set to 0.3 by default.